### PR TITLE
Extended View class to IntersectionView

### DIFF
--- a/react/src/lib/components/DeckGLMap/components/Map.tsx
+++ b/react/src/lib/components/DeckGLMap/components/Map.tsx
@@ -470,6 +470,8 @@ function getViews(views: ViewsType | undefined): Record<string, unknown>[] {
                 const cur_viewport = views.viewports[deckgl_views.length];
                 const view_type: string = cur_viewport.show3D
                     ? "OrbitView"
+                    : cur_viewport.id === "intersection_view"
+                    ? "IntersectionView"
                     : "OrthographicView";
                 const id_suffix = cur_viewport.show3D ? "_3D" : "_2D";
                 const view_id: string = cur_viewport.id + id_suffix;

--- a/react/src/lib/components/DeckGLMap/layers/wells/wellsLayer.ts
+++ b/react/src/lib/components/DeckGLMap/layers/wells/wellsLayer.ts
@@ -110,7 +110,7 @@ export default class WellsLayer extends CompositeLayer<
             : (this.props.data as FeatureCollection);
 
         const is3d = this.context.viewport.constructor.name === "OrbitViewport";
-        const positionFormat = is3d ? "XYZ" : "XY";
+        const positionFormat = is3d ? "XYZ" : "XYZ";
 
         const outline = new GeoJsonLayer<Feature>(
             this.getSubLayerProps<Feature>({

--- a/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
+++ b/react/src/lib/components/DeckGLMap/storybook/DeckGLMap.stories.jsx
@@ -446,6 +446,35 @@ ExperimentalMapLayerFloat32Property.args = {
     },
 };
 
+// Intersection view example
+export const IntersectionView = EditDataTemplate.bind({});
+IntersectionView.args = {
+    ...exampleData[0],
+    legend: {
+        visible: false,
+    },
+    zoom: -3.5,
+    layers: [...exampleData[0].layers, axes],
+    views: {
+        layout: [1, 2],
+        showLabel: true,
+        viewports: [
+            {
+                id: "map-view",
+                name: "Map view",
+                show3D: false,
+                layerIds: ["axes-layer", "wells-layer"],
+            },
+            {
+                id: "intersection_view",
+                name: "Intersection view",
+                show3D: false,
+                layerIds: ["axes-layer", "wells-layer"],
+            },
+        ],
+    },
+};
+
 ExperimentalMapLayerFloat32Property.parameters = {
     title: "Test",
     docs: {

--- a/react/src/lib/components/DeckGLMap/utils/configuration.ts
+++ b/react/src/lib/components/DeckGLMap/utils/configuration.ts
@@ -19,6 +19,7 @@ import { registerLoaders } from "@loaders.gl/core";
 import GL from "@luma.gl/constants";
 
 import * as CustomLayers from "../layers";
+import * as CustomViews from "../views";
 
 // Note: deck already registers JSONLoader...
 registerLoaders([]);
@@ -27,7 +28,14 @@ export default {
     // Classes that should be instantiatable by JSON converter
     classes: Object.assign(
         // Support `@deck.gl/core` Views
-        { FirstPersonView, MapView, OrbitView, OrthographicView },
+        {
+            FirstPersonView,
+            MapView,
+            OrbitView,
+            OrthographicView,
+            ...CustomViews,
+        },
+
         // a map of all layers that should be exposes as JSONLayers
         Layers,
         AggregationLayers,

--- a/react/src/lib/components/DeckGLMap/views/index.js
+++ b/react/src/lib/components/DeckGLMap/views/index.js
@@ -1,0 +1,1 @@
+export { default as IntersectionView } from "./intersection/intersectionView";

--- a/react/src/lib/components/DeckGLMap/views/intersection/intersectionView.js
+++ b/react/src/lib/components/DeckGLMap/views/intersection/intersectionView.js
@@ -1,0 +1,124 @@
+import { OrthographicController, View, Viewport } from "@deck.gl/core";
+
+import { Matrix4 } from "@math.gl/core";
+import { pixelsToWorld } from "@math.gl/web-mercator";
+import * as vec2 from "gl-matrix/vec2";
+
+// Displaying in 2d view XZ plane by configuring the view matrix
+const viewMatrix = new Matrix4().lookAt({
+    eye: [0, 1, 0],
+    up: [0, 0, 1],
+    //center: [0, 0, 0],
+});
+
+function getProjectionMatrix({ width, height, near, far }) {
+    // Make sure Matrix4.ortho doesn't crash on 0 width/height
+    width = width || 1;
+    height = height || 1;
+
+    return new Matrix4().ortho({
+        left: -width / 2,
+        right: width / 2,
+        bottom: -height / 2,
+        top: height / 2,
+        near,
+        far,
+    });
+}
+
+class IntersectionViewport extends Viewport {
+    constructor(props) {
+        const {
+            width,
+            height,
+            near = 0.1,
+            far = 1000,
+            zoom = 0,
+            target = [0, 0, 0],
+            flipY = true,
+        } = props;
+        const zoomX = Array.isArray(zoom) ? zoom[0] : zoom;
+        const zoomY = Array.isArray(zoom) ? zoom[1] : zoom;
+        const zoomZ = Array.isArray(zoom) ? zoom[2] : zoom;
+        const zoom_ = Math.min(zoomX, zoomY, zoomZ);
+        const scale = Math.pow(2, zoom_);
+
+        let distanceScales;
+        if (zoomX !== zoomY) {
+            const scaleX = Math.pow(2, zoomX);
+            const scaleY = Math.pow(2, zoomY);
+            const scaleZ = Math.pow(2, zoomZ);
+
+            distanceScales = {
+                unitsPerMeter: [scaleX / scale, scaleY / scale, scaleZ / scale],
+                metersPerUnit: [scale / scaleX, scale / scaleY, scale / scaleZ],
+            };
+        }
+
+        super({
+            ...props,
+            // in case viewState contains longitude/latitude values,
+            // make sure that the base Viewport class does not treat this as a geospatial viewport
+            longitude: null,
+            position: target,
+            viewMatrix: viewMatrix
+                .clone()
+                .scale([scale, scale * (flipY ? -1 : 1), scale]),
+            projectionMatrix: getProjectionMatrix({ width, height, near, far }),
+            zoom: zoom_,
+            distanceScales,
+        });
+    }
+
+    // copied from OrthographicView
+    projectFlat([X, Y, Z]) {
+        const { unitsPerMeter } = this.distanceScales;
+        return [
+            X * unitsPerMeter[0],
+            Y * unitsPerMeter[1],
+            Z * unitsPerMeter[2],
+        ];
+    }
+
+    unprojectFlat([x, y, z]) {
+        const { metersPerUnit } = this.distanceScales;
+        return [
+            x * metersPerUnit[0],
+            y * metersPerUnit[1],
+            z * metersPerUnit[2],
+        ];
+    }
+
+    // copied from OrthographicView
+    /* Needed by LinearInterpolator */
+    panByPosition(coords, pixel) {
+        const fromLocation = pixelsToWorld(pixel, this.pixelUnprojectionMatrix);
+        const toLocation = this.projectFlat(coords);
+
+        const translate = vec2.add(
+            [],
+            toLocation,
+            vec2.negate([], fromLocation)
+        );
+        const newCenter = vec2.add([], this.center, translate);
+
+        return { target: this.unprojectFlat(newCenter) };
+    }
+}
+
+export default class IntersectionView extends View {
+    constructor(props) {
+        super({
+            ...props,
+            type: IntersectionViewport,
+        });
+    }
+
+    get controller() {
+        return this._getControllerProps({
+            type: OrthographicController,
+        });
+    }
+}
+
+IntersectionView.displayName = "IntersectionView";


### PR DESCRIPTION
Extended View class to IntersectionView
In this example simply changing the view matrix to display XZ plane.
(Without unfolding the data)